### PR TITLE
added listKey prop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,7 @@ class Column extends React.Component {
 		return <View style={{ flex: 1, overflow: "hidden" }}>
 			<FlatList
 				style={{ flex: 1 }}
+				listKey={this.props.listKey}
 				data={this.state.data}
 				keyExtractor={this.props.keyExtractor}
 				renderItem={this.renderItem.bind( this )}
@@ -144,7 +145,7 @@ export default class Masonry extends React.Component {
 			{this.props.header}
 			<View style={[ { flexDirection: "row" }, this.props.containerStyle ]}>
 				{this.state.columns.map( ( col, index ) => {
-					return <Column key={index} ref={( ref ) => this.state.columns[ index ] = ref}
+					return <Column key={index} listKey={index} ref={( ref ) => this.state.columns[ index ] = ref}
 								   keyExtractor={this.props.keyExtractor}
 								   renderItem={this.props.renderItem.bind( this )}/>
 				} )}


### PR DESCRIPTION
listKey prop prevents an error when multiple flat lists are nested with no differentiating factor.

Link to error: [https://stackoverflow.com/questions/49276526/nested-flat-list-invariant-violation-a-virtualizedlist-contains-a-cell-which-it?rq=1](https://stackoverflow.com/questions/49276526/nested-flat-list-invariant-violation-a-virtualizedlist-contains-a-cell-which-it?rq=1)